### PR TITLE
Update missing_dependencies.sh apt install issue

### DIFF
--- a/plugins/missing_dependencies.sh
+++ b/plugins/missing_dependencies.sh
@@ -262,7 +262,7 @@ function missing_dependencies_posthook_check_compatibility() {
 			local resultok=0
 			case "${distro}" in
 				"Kali"|"Parrot")
-					if apt update > /dev/null 2>&1 && apt -y install "${missing_packages_string_clean}" > /dev/null 2>&1; then
+					if apt update > /dev/null 2>&1 && apt -y install ${missing_packages_string_clean} > /dev/null 2>&1; then
 						resultok=1
 					fi
 				;;


### PR DESCRIPTION
Double quote the list of packages makes apt to think all packages are only one.
apt get install "pkg1 pkg2" --> can't install

<!--- Please, before sending a pull request read the Git Workflow Policy on Contributing section of the project -->
<!--- If you have doubts about how to proceed, consider to contact us on Discord or IRC before doing the PR. More info and Discord invitation link here: https://github.com/v1s1t0r1sh3r3/airgeddon/wiki/Contact -->
<!--- Pull requests to master are not allowed -->
<!--- Write in English only -->
<!--- If your pull request is about a plugin, don't do it! airgeddon is not storing plugins. Read this about what to do: https://github.com/v1s1t0r1sh3r3/airgeddon/wiki/Plugins%20Hall%20of%20Fame -->
<!--- If the pull request is not matching the policy, it will be closed -->

#### Describe the purpose of the pull request

<!--- Insert answer here -->
