### PR TITLE
Fix auto_update problem on some distros

### DIFF
--- a/plugins/missing_dependencies.sh
+++ b/plugins/missing_dependencies.sh
@@ -206,7 +206,7 @@ function missing_dependencies_text() {
 }
 
 #Posthook for check_compatibity function to install missing dependencies
-#shellcheck disable=SC2154
+#shellcheck disable=SC2154,SC2086
 function missing_dependencies_posthook_check_compatibility() {
 
 	if [[ ${essential_toolsok} -ne 1 ]] || [[ ${optional_toolsok} -ne 1 ]] || [[ ${update_toolsok} -ne 1 ]]; then
@@ -262,12 +262,12 @@ function missing_dependencies_posthook_check_compatibility() {
 			local resultok=0
 			case "${distro}" in
 				"Kali"|"Parrot")
-					if apt update > /dev/null 2>&1 && apt -y install "${missing_packages_string_clean}" > /dev/null 2>&1; then
+					if apt update > /dev/null 2>&1 && apt -y install ${missing_packages_string_clean} > /dev/null 2>&1; then
 						resultok=1
 					fi
 				;;
 				"BlackArch")
-					if pacman -Sy > /dev/null 2>&1 && pacman --noconfirm -S "${missing_packages_string_clean}" > /dev/null 2>&1; then
+					if pacman -Sy > /dev/null 2>&1 && pacman --noconfirm -S ${missing_packages_string_clean} > /dev/null 2>&1; then
 						resultok=1
 					fi
 				;;


### PR DESCRIPTION
Double quote on list of packages, makes apt to think all packages are only one package name
apt install "pkg1 pkg2" ---> can't install pakage "pkg1 pkg2"
