### PR TITLE
Takes into account networks with power <0%

### DIFF
--- a/airgeddon.sh
+++ b/airgeddon.sh
@@ -12302,7 +12302,7 @@ function explore_for_wps_targets_option() {
 				fi
 			fi
 
-			if [[ ${expwps_power} -le 9 ]]; then
+			if [[ ${expwps_power} -le 9 ]] && [[ ${expwps_power} -ge 0 ]]; then
 				wpssp4=" "
 			else
 				wpssp4=""
@@ -12403,7 +12403,7 @@ function select_target() {
 			exp_power=0
 		fi
 
-		if [[ ${exp_power} -le 9 ]]; then
+		if [[ ${exp_power} -le 9 ]] && [[ ${exp_power} -ge 0 ]]; then
 			sp4=" "
 		else
 			sp4=""


### PR DESCRIPTION
### Describe the purpose of the pull request

Hi, in explore_for_wps_targets_option and select_target windows, if a target's power is less then 0%, it's "space" should be empty, otherwise that line will be shifted to the right:
```
  1)   AA:BB:CC:00:00:00    9    10%   WPA2   ESSID
  2)   AA:BB:CC:00:00:00    9     8%   WPA2   ESSID
  3)   AA:BB:CC:00:00:00    1     8%   WPA2   ESSID
  4)   AA:BB:CC:00:00:00    1     -7%   WPA2   ESSID
```
this commit takes into account networks with power <0%

Regards