### PR TITLE
fix restoring spoofed_mac flag

### DIFF
--- a/airgeddon.sh
+++ b/airgeddon.sh
@@ -9206,6 +9206,8 @@ function restore_spoofed_macs() {
 		ip link set dev "${item}" address "${original_macs[${item}]}" > /dev/null 2>&1
 		ip link set "${item}" up > /dev/null 2>&1
 	done
+	
+	spoofed_mac=0
 }
 
 #Set routing state and firewall rules for Evil Twin attacks


### PR DESCRIPTION
#### Describe the purpose of the pull request

Without plugins, airgeddon does not needs to restore spoofed_mac flag, as restore_spoofed_macs() function used only once - before application exit.
But in spoof_mac_automatically plugin (https://github.com/Bogdan107/airgeddon_plugins/blob/main/spoof_mac_automatically.sh), this flag required for correct spoofing/restoring MAC-address.