### PR TITLE
update airgeddon.sh - precheck for mac_spoofing_desired

### DIFF
--- a/airgeddon.sh
+++ b/airgeddon.sh
@@ -12856,9 +12856,11 @@ function et_prerequisites() {
 		fi
 	fi
 
-	ask_yesno 419 "no"
-	if [ "${yesno}" = "y" ]; then
-		mac_spoofing_desired=1
+	if [[ -z mac_spoofing_desired ]] || [[ ${mac_spoofing_desired} -eq 0 ]]; then
+		ask_yesno 419 "no"
+		if [ "${yesno}" = "y" ]; then
+			mac_spoofing_desired=1
+		fi
 	fi
 
 	if [ "${et_mode}" = "et_captive_portal" ]; then


### PR DESCRIPTION
The patch allows to simplify the code of an external plugin.
Relevant for spoof_mac_automatically  plugin (https://github.com/Bogdan107/airgeddon_plugins/blob/main/spoof_mac_automatically.sh).

Currently the "spoof_mac_automatically" plugin needs to override the "et_prerequisites" function, which contains about 200 lines of code.
With this patch, an external plugin can silently suppress the MAC spoofing request in "et_prerequisites" without copying 200 lines of code.

Why do I need this if the plugin can use the override function?
Any changes to the code of the original "et_prerequisites" function increase the distance between the plugin code and the original.
In future updates, if the et_prerequisites function code changes, the plugin must also be updated.
Thus, I needs sometimes to keep track of the er_prerequisites function code and update the plugin code.
With this patch, the external plugin does not need to be synchronized with the original et_prerequisites function.
