### PR TITLE
update airgeddon.sh - precheck for mac_spoofing_desired in et_prerequisites()

### DIFF
--- a/airgeddon.sh
+++ b/airgeddon.sh
@@ -12962,9 +12962,11 @@ function et_prerequisites() {
 		fi
 	fi
 
-	ask_yesno 419 "no"
-	if [ "${yesno}" = "y" ]; then
-		mac_spoofing_desired=1
+	if [[ -z mac_spoofing_desired ]] || [[ ${mac_spoofing_desired} -eq 0 ]]; then
+		ask_yesno 419 "no"
+		if [ "${yesno}" = "y" ]; then
+			mac_spoofing_desired=1
+		fi
 	fi
 
 	if [ "${et_mode}" = "et_captive_portal" ]; then

--- a/airgeddon.sh
+++ b/airgeddon.sh
@@ -12962,7 +12962,7 @@ function et_prerequisites() {
 		fi
 	fi
 
-	if [[ -z mac_spoofing_desired ]] || [[ ${mac_spoofing_desired} -eq 0 ]]; then
+	if [[ -z "${mac_spoofing_desired}" ]] || [[ ${mac_spoofing_desired} -eq 0 ]]; then
 		ask_yesno 419 "no"
 		if [ "${yesno}" = "y" ]; then
 			mac_spoofing_desired=1


### PR DESCRIPTION
Patch allows to simplify the code of an external plugin.
Relevant for spoof_mac_automatically  plugin (https://github.com/Bogdan107/airgeddon_plugins/blob/main/spoof_mac_automatically.sh).

Currently the "spoof_mac_automatically" plugin needs to override the "et_prerequisites" function, which contains about 200 lines of code.
With this patch, an external plugin can silently suppress the MAC spoofing request in  prehook of "et_prerequisites" without copying 200 lines of code.

**Why do I need this** if the plugin can use the override function?
Any changes to the code of the original "et_prerequisites" function increase the distance between the plugin code and the original code.
In future updates, if the et_prerequisites function code changes, the plugin must also be updated.
Thus, I needs sometimes to keep track code of the et_prerequisites function and update the code of plugin.
With this patch, the external plugin does not need to be synchronized with the original et_prerequisites function.