### PR TITLE
update for pciutils 3.8

### DIFF
--- a/airgeddon.sh
+++ b/airgeddon.sh
@@ -2368,7 +2368,7 @@ function set_chipset() {
 
 		elif [[ "${bus_type}" =~ pci|ssb|bcma|pcmcia ]]; then
 			if [[ -f /sys/class/net/${1}/device/vendor ]] && [[ -f /sys/class/net/${1}/device/device ]]; then
-				vendor_and_device=$(cat "/sys/class/net/${1}/device/vendor"):$(cat "/sys/class/net/${1}/device/device")
+				vendor_and_device=$(sed -e 's/0x//' "/sys/class/net/${1}/device/vendor"):$(sed -e 's/0x//' "/sys/class/net/${1}/device/device")
 				if [[ -n "${2}" ]] && [[ "${2}" = "read_only" ]]; then
 					requested_chipset=$(lspci -d "${vendor_and_device}" | head -n 1 | cut -f 3 -d ":" | sed -e "${sedruleall}")
 				else


### PR DESCRIPTION
pciutils 3.8 lspci doesn't accept lspci -d 0xBLAH:0xBLAH and only
permits lspci -d BLAH:BLAH.  Both pciutils 3.7 and 3.8 accept it without
0x, so just always remove 0x

Reported-by: ClawS
See-Also: https://github.com/aircrack-ng/aircrack-ng/commit/735a67969aa81fe1072f5f2d8c3337e21a2504c5