### PR TITLE
Replace all spaces in captive portal password

### DIFF
--- a/airgeddon.sh
+++ b/airgeddon.sh
@@ -11419,7 +11419,7 @@ function set_captive_portal_page() {
 		POST_DATA=$(cat /dev/stdin)
 		if [[ "${REQUEST_METHOD}" = "POST" ]] && [[ "${CONTENT_LENGTH}" -gt 0 ]]; then
 			POST_DATA=${POST_DATA#*=}
-			password=${POST_DATA/+/ }
+			password=${POST_DATA//+/ }
 			password=${password//[*&\/?<>]}
 			password=$(printf '%b' "${password//%/\\x}")
 			password=${password//[*&\/?<>]}


### PR DESCRIPTION

When capturing the password from the captive portal, the post data is cleaned by replacing `+` with a space. This fails to replace all instances of `+` and leads to multi-space passwords with only the first space present.

Actual password:
```
this is the password
```
Processed password captured from captive portal
```
this is+the+password
```