### PR TITLE
Optimize DOS Pursuit mode process killing by using recursive killing …

### DIFF
--- a/airgeddon.sh
+++ b/airgeddon.sh
@@ -12359,8 +12359,7 @@ function kill_dos_pursuit_mode_processes() {
 	debug_print
 
 	for item in "${dos_pursuit_mode_pids[@]}"; do
-		kill -9 "${item}" &> /dev/null
-		wait "${item}" 2> /dev/null
+		kill_pid_and_children_recursive "${item}"
 	done
 
 	if ! stty sane > /dev/null 2>&1; then


### PR DESCRIPTION
Optimize DOS Pursuit mode process killing by using recursive killing of all child processes

<!--- Please, before sending a pull request read the Git Workflow Policy on Contributing section of the project -->
<!--- If you have doubts about how to proceed, consider to contact us on Discord or IRC before doing the PR. More info and Discord invitation link here: https://github.com/v1s1t0r1sh3r3/airgeddon/wiki/Contact -->
<!--- Pull requests to master are not allowed -->
<!--- Write in English only -->
<!--- If your pull request is about a plugin, don't do it! airgeddon is not storing plugins. Read this about what to do: https://github.com/v1s1t0r1sh3r3/airgeddon/wiki/Plugins%20Hall%20of%20Fame -->
<!--- If the pull request is not matching the policy, it will be closed -->

#### Describe the purpose of the pull request

<!--- Insert answer here -->
Oscar, the boss instructed me to solve the problem of fake AP not being able to be launch after switching channels in DOS Pursuit mode
