### PR TITLE
This PR fixes an issue in the analyze_wpa3_mfp_status function where tshark misinterprets the MFP status on WPA3-Transitional (sae-mixed) networks and handles varying tshark output formats.

### DIFF
--- a/airgeddon.sh
+++ b/airgeddon.sh
@@ -4571,13 +4571,33 @@ function analyze_wpa3_mfp_status() {
 	fi
 
 	mfp_analysis_capture_file="${tmpdir}mfp_analysis-01.cap"
-	if tshark -r "${mfp_analysis_capture_file}" -Y "wlan.sa == ${bssid} && wlan.fc.type_subtype == 0x08 && wlan.rsn.capabilities.mfpr == 1" -T fields -e wlan.sa 2> /dev/null | grep -q .; then
-		mfp_status="required"
-	elif tshark -r "${mfp_analysis_capture_file}" -Y "wlan.sa == ${bssid} && wlan.fc.type_subtype == 0x08 && wlan.rsn.capabilities.mfpc == 1 && wlan.rsn.capabilities.mfpr == 0" -T fields -e wlan.sa 2> /dev/null | grep -q .; then
-		mfp_status="capable"
-	elif tshark -r "${mfp_analysis_capture_file}" -Y "wlan.sa == ${bssid} && wlan.fc.type_subtype == 0x08 && wlan.rsn.capabilities.mfpc == 0 && wlan.rsn.capabilities.mfpr == 0" -T fields -e wlan.sa 2> /dev/null | grep -q .; then
-		mfp_status="disabled"
+	# Filtere gezielt nach Paketen, die RSN Capabilities enthalten und nehme die erste gültige Zeile
+	mfp_fields=$(tshark -r "${mfp_analysis_capture_file}" -Y "wlan.sa == ${bssid} && wlan.fc.type_subtype == 0x08 && wlan.rsn.capabilities.mfpc" -T fields -e wlan.rsn.capabilities.mfpc -e wlan.rsn.capabilities.mfpr 2> /dev/null | grep -E "True|False|1|0" | head -n 1)
+
+	if [ -n "${mfp_fields}" ]; then
+		mfpc=$(echo "${mfp_fields}" | awk '{print $1}' | cut -d',' -f1)
+		mfpr=$(echo "${mfp_fields}" | awk '{print $2}' | cut -d',' -f1)
+
+		# Normalisiere True/False zu 1/0 für einheitliche Abfragen
+		[ "${mfpc}" = "True" ] && mfpc="1"
+		[ "${mfpc}" = "False" ] && mfpc="0"
+		[ "${mfpr}" = "True" ] && mfpr="1"
+		[ "${mfpr}" = "False" ] && mfpr="0"
+
+		if [ "${mfpc}" = "1" ] && [ "${mfpr}" = "1" ]; then
+			mfp_status="required"
+		elif [ "${mfpc}" = "1" ] && [ "${mfpr}" = "0" ]; then
+			mfp_status="capable"
+		elif [ "${mfpc}" = "0" ] && [ "${mfpr}" = "0" ]; then
+			mfp_status="disabled"
+		else
+			mfp_status="unknown"
+		fi
 	else
+		mfp_status="unknown"
+	fi
+
+	if [ "${mfp_status}" = "unknown" ]; then
 		echo
 		language_strings "${language}" 842 "red"
 		language_strings "${language}" 115 "read"

--- a/airgeddon.sh
+++ b/airgeddon.sh
@@ -4571,14 +4571,12 @@ function analyze_wpa3_mfp_status() {
 	fi
 
 	mfp_analysis_capture_file="${tmpdir}mfp_analysis-01.cap"
-	# Filtere gezielt nach Paketen, die RSN Capabilities enthalten und nehme die erste gültige Zeile
 	mfp_fields=$(tshark -r "${mfp_analysis_capture_file}" -Y "wlan.sa == ${bssid} && wlan.fc.type_subtype == 0x08 && wlan.rsn.capabilities.mfpc" -T fields -e wlan.rsn.capabilities.mfpc -e wlan.rsn.capabilities.mfpr 2> /dev/null | grep -E "True|False|1|0" | head -n 1)
 
 	if [ -n "${mfp_fields}" ]; then
 		mfpc=$(echo "${mfp_fields}" | awk '{print $1}' | cut -d',' -f1)
 		mfpr=$(echo "${mfp_fields}" | awk '{print $2}' | cut -d',' -f1)
 
-		# Normalisiere True/False zu 1/0 für einheitliche Abfragen
 		[ "${mfpc}" = "True" ] && mfpc="1"
 		[ "${mfpc}" = "False" ] && mfpc="0"
 		[ "${mfpr}" = "True" ] && mfpr="1"


### PR DESCRIPTION
Issues fixed:

In sae-mixed mode, the base RSN capability correctly broadcasts MFPR=0 & MFPC=1. However, the beacon often contains a later Vendor Specific: Wi-Fi Alliance: RSN Extension Element Override tag. The previous tshark display filter matched mfpr==1 anywhere in the packet, falsely triggering the "required" status.

Depending on the OS and tshark version, wlan.rsn.capabilities.mfpc outputs as True/False instead of 1/0, which caused the script to fail and return an "unknown" error.

Changes:

Changed tshark to output the raw fields of the first valid frame instead of using the display filter for evaluation.

Handled commas using awk and cut to strictly grab the first Base RSN element, ignoring Extension Overrides.

Added normalization to convert True/False into 1/0 strings.