### PR TITLE
Allow startup on WSL

### DIFF
--- a/airgeddon.sh
+++ b/airgeddon.sh
@@ -18566,20 +18566,6 @@ function general_checkings() {
 	exit_script_option
 }
 
-#Check if system is running under Windows Subsystem for Linux
-check_wsl() {
-
-	debug_print
-
-	if [ "${distro}" = "Microsoft" ]; then
-		echo
-		language_strings "${language}" 701 "red"
-		language_strings "${language}" 115 "read"
-		exit_code=1
-		exit_script_option
-	fi
-}
-
 #Check if the user is root
 function check_root_permissions() {
 
@@ -20622,7 +20608,6 @@ function main() {
 
 		check_bash_version
 		check_root_permissions
-		check_wsl
 
 		if [ "${AIRGEDDON_WINDOWS_HANDLING}" = "xterm" ]; then
 			echo


### PR DESCRIPTION
#### Describe the purpose of the pull request

Remove the startup check that unconditionally exits when airgeddon detects Windows Subsystem for Linux. This allows users to proceed on WSL while preserving the existing Bash version and root permission checks.

Validation: `bash -n airgeddon.sh`; `git diff origin/dev...HEAD --check`